### PR TITLE
Fixes missing headers to compile under g++.

### DIFF
--- a/ginger.h
+++ b/ginger.h
@@ -10,6 +10,8 @@
 #include <vector>
 #include <cassert>
 #include <iterator>
+#include <functional>
+#include <memory>
 
 namespace ginger {
 


### PR DESCRIPTION
* Missing <functional> and <memory> for std::function<> and
std::shared_ptr<>, causing failures to compile under g++.
* Compiled and tested under -Wall -pedantic without any issue (warning
were ignored).

I've stumbled upon compilation issues while adding to my project compiled under g++ 7.3. 
It seems that clang++ is much more forgiving concerning this. 